### PR TITLE
Disable digest pinning for GitHub Actions and Dockerfile base images

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,9 @@ In a repo's `renovate.json`:
 ```
 
 This resolves to [`default.json`](default.json), which pulls in [`shared.json`](shared.json) —
-the common baseline: `config:recommended`, assignee/label/timezone, GitHub Action digest pinning,
-Dockerfile digest pinning, and automerge for low-risk CI plumbing updates.
+the common baseline: `config:recommended`, assignee/label/timezone, and automerge for low-risk CI
+plumbing updates. Dependencies are intentionally left unpinned (no digest pinning for GitHub
+Actions or Dockerfile base images) — updates land as normal version-bump PRs instead.
 
 ## Optional extras
 

--- a/shared.json
+++ b/shared.json
@@ -3,7 +3,6 @@
   "extends": [
     "config:recommended",
     "docker:enableMajor",
-    "helpers:pinGitHubActionDigests",
     ":maintainLockFilesWeekly"
   ],
   "assignees": ["modem7"],
@@ -21,11 +20,6 @@
       "matchManagers": ["github-actions", "woodpecker"],
       "matchUpdateTypes": ["minor", "patch", "digest"],
       "automerge": true
-    },
-    {
-      "description": "Pin Dockerfile base image digests",
-      "matchManagers": ["dockerfile"],
-      "pinDigests": true
     }
   ],
   "customManagers": [


### PR DESCRIPTION
## Summary
- Removes `helpers:pinGitHubActionDigests` and the Dockerfile `pinDigests` packageRule from `shared.json` — digest pinning wasn't wanted here.
- This setting had already gone live via #6 and produced a "Pin dependencies" / "Pin X action to \<sha\>" PR on every repo extending this config. Those are being closed out separately since the rule that created them is gone.

## Test plan
- [x] `renovate-config-validator` passes for `shared` and `default`