### PR TITLE
Disable docker:enableMajor

### DIFF
--- a/shared.json
+++ b/shared.json
@@ -2,7 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
-    "docker:enableMajor",
     ":maintainLockFilesWeekly"
   ],
   "assignees": ["modem7"],


### PR DESCRIPTION
## Summary
Removes \`docker:enableMajor\` from \`shared.json\`. Docker image major-version updates are no longer proposed by default across repos extending this config — only minor/patch. A repo that wants major bumps can add \`docker:enableMajor\` to its own extends.

## Test plan
- [x] \`renovate-config-validator\` passes for \`shared\`